### PR TITLE
Add gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hugo-theme-geppaku"]
-	path = theme/hugo-theme-geppaku
+	path = themes/hugo-theme-geppaku
 	url = https://github.com/masa0221/hugo-theme-geppaku

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hugo-theme-geppaku"]
+	path = theme/hugo-theme-geppaku
+	url = https://github.com/masa0221/hugo-theme-geppaku

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,10 @@
 box: debian
 build:
   steps:
+    - script:
+      name: initialize git submodules
+      code: |
+        git submodule update --init --recursive
     - arjen/hugo-build:
       version: 0.14
       theme: hugo-theme-geppaku

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,6 +1,8 @@
 box: debian
 build:
   steps:
+    - install-packages:
+      packages: git ssh-client
     - script:
       name: initialize git submodules
       code: |


### PR DESCRIPTION
Issue https://github.com/litmon/techblog/issues/29
記事が上手く生成されないバグ

.gitmodulesに追加してないのと、werckerの設定でrecursiveに取得していなかったせいで`themes/hugo-theme-geppaku`の中身が空になってしまっていた
